### PR TITLE
 Add "click-and-drag-to-buy" feature to upgrades

### DIFF
--- a/js/components.js
+++ b/js/components.js
@@ -172,7 +172,7 @@ function loadVue() {
 	Vue.component('upgrade', {
 		props: ['layer', 'data'],
 		template: `
-		<button v-if="tmp[layer].upgrades && tmp[layer].upgrades[data]!== undefined && tmp[layer].upgrades[data].unlocked" :id='"upgrade-" + layer + "-" + data' v-on:click="buyUpg(layer, data)" v-bind:class="{ [layer]: true, tooltipBox: true, upg: true, bought: hasUpgrade(layer, data), locked: (!(canAffordUpgrade(layer, data))&&!hasUpgrade(layer, data)), can: (canAffordUpgrade(layer, data)&&!hasUpgrade(layer, data))}"
+		<button v-if="tmp[layer].upgrades && tmp[layer].upgrades[data]!== undefined && tmp[layer].upgrades[data].unlocked" :id='"upgrade-" + layer + "-" + data' v-on:mousedown="handleMouseEvent" v-on:mouseenter="handleMouseEvent" v-bind:class="{ [layer]: true, tooltipBox: true, upg: true, bought: hasUpgrade(layer, data), locked: (!(canAffordUpgrade(layer, data))&&!hasUpgrade(layer, data)), can: (canAffordUpgrade(layer, data)&&!hasUpgrade(layer, data))}"
 			v-bind:style="[((!hasUpgrade(layer, data) && canAffordUpgrade(layer, data)) ? {'background-color': tmp[layer].color} : {}), tmp[layer].upgrades[data].style]">
 			<span v-if="layers[layer].upgrades[data].fullDisplay" v-html="run(layers[layer].upgrades[data].fullDisplay, layers[layer].upgrades[data])"></span>
 			<span v-else>
@@ -184,7 +184,15 @@ function loadVue() {
 			<tooltip v-if="tmp[layer].upgrades[data].tooltip" :text="tmp[layer].upgrades[data].tooltip"></tooltip>
 
 			</button>
-		`
+		`,
+		methods: {
+			handleMouseEvent(event) {
+				// event.buttons is a bitmask, 0b1 is primary mouse button (usually left)
+				if (event.buttons & 1) {
+					buyUpg(this.layer, this.data)
+				}
+			}
+		}
 	})
 
 	Vue.component('milestones', {


### PR DESCRIPTION
(I originally implemented this for pg132s Tree of Life, but I thought it could be nice to have in base as well)

This PR adds a "click-and-drag-to-buy" feature to upgrades, i.e. you can buy all upgrades in a layer by holding down the left mouse button and dragging your mouse over the buttons. Only one event is fired per element, so no performance regression.

The only unfortunate change is that you can no longer cancel buying an upgrade, i.e. click the button, drag the mouse away and release it, since this will buy on `mousedown` instead of `mouseup` as previously. If you want I think it should be easy to implement it so you only buy the current upgrade if you do mouseup on it or drag the mouse onto another unbought upgrade, so you could always cancel by dragging onto a bought upgrade or the empty space, but this behavior might be a bit confusing.