### PR TITLE
Githack Redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 	<script src="js/technical/layerSupport.js"></script>
 
 	<script src="js/game.js"></script>
+	<script src="js/technical/githack-redirect.js"></script>
 	<script src="js/technical/loader.js"></script>
 
 	<script src="js/technical/temp.js"></script>

--- a/js/game.js
+++ b/js/game.js
@@ -8,7 +8,7 @@ let gameInfo = {
 	discordName: "",
 	discordLink: "",
 	initialStartPoints: new Decimal (10), // Used for hard resets and new players
-	githackBranch: "feature/githack-redirect",
+	githackBranch: "",
 	offlineLimit: 1,  // In hours
 }
 

--- a/js/game.js
+++ b/js/game.js
@@ -8,6 +8,7 @@ let gameInfo = {
 	discordName: "",
 	discordLink: "",
 	initialStartPoints: new Decimal (10), // Used for hard resets and new players
+	githackBranch: "feature/githack-redirect",
 	offlineLimit: 1,  // In hours
 }
 

--- a/js/technical/githack-redirect.js
+++ b/js/technical/githack-redirect.js
@@ -1,0 +1,22 @@
+if (gameInfo.githackBranch && window.location.hostname === "rawcdn.githack.com") {
+	// Parse the current user and repo from the URL
+	const parts = window.location.pathname.split('/');
+	const user = parts[1];
+	const repo = parts[2];
+
+	// Find latest commit on specified branch
+	fetch(`https://api.github.com/repos/${user}/${repo}/commits/${gameInfo.githackBranch}`)
+	.then(response => response.json())
+	.then(response => {
+		// Calculate the URL for the latest version of the mod
+		const updatedURL = `https://rawcdn.githack.com/${user}/${repo}/${response.sha}/index.html?min=1`;
+
+		// Do nothing if we're already on that URL
+		if (updatedURL === window.location.href) {
+			return;
+		}
+
+		// Redirect to the latest version of the mod
+		window.location.href = updatedURL;
+	});
+}


### PR DESCRIPTION
This adds a new file that checks if the game is being played on a githack production URL, and if so checks if there's a more recent commit on the branch specified in modInfo. If there's a more recent commit, it redirects to the production URL for that commit.

This change will encourage developers to use the production URLs instead of development URLs.

![image](https://user-images.githubusercontent.com/3683148/153731506-543e13d5-524b-49de-bcad-ef00801ce6be.png)
